### PR TITLE
Windows port

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ A future version of Slicer4RTN might segment volumes and support multiple conic 
 * When calling Slic3r, you must give the full path to the slic3r-console.exe file.
 * When calling PrusaSlicer, you must give the full path to the prusa-slicer-console.exe file.
 * When calling Cura, you must give the full path to the CuraEngine.exe file.
+* Global files are installed under `C:\ProgData\slicer4rtn` .  Specifically, the script itself is installed under `C:\ProgData\slicer4rtn\bin\slicer4rtn`  
+* Local files are installed under `%APPDATA%\slicer4rtn` .  
+
 ## Updates
 - 0.6.0: $efa multiplier adjusted, --rot-revolve=0 (new default, unlimited revolv), --rot-revolve=1 (single revolv) does performs smart rotate-around to immitate continenous rotation
 - 0.5.2: --rotate, --scale and --translate added for pre-processing model

--- a/README.md
+++ b/README.md
@@ -19,7 +19,12 @@ A future version of Slicer4RTN might segment volumes and support multiple conic 
 
 ## Supported Platforms
 - Linux Ubuntu/Debian, tested on Ubuntu 20.04 LTS
+- Windows (tested on Windows 10)
 
+## Windows Notes
+* When calling Slic3r, you must give the full path to the slic3r-console.exe file, but you MUST drop the .exe suffix, and write slic3r-console in all lowercase, even if the file is installed as Slic3r-console.exe . For example: `--slicer=c:\instpath\slic3r\slic3r-console`
+* When calling PrusaSlicer, you must give the full path to the prusa-slicer-console.exe file, but you MUST drop the .exe suffix, and write prusa-slicer-console in all lowercase. For example: `--slicer=c:\instpath\PrusaSlicer\prusa-slicer-console`
+* When calling Cura, you must give the full path to the CuraEngine.exe file, but you MUST drop the .exe suffix, and write CuraEngine in the exact form as here (2 capitalized words). For example: `--slicer=c:\instpath\Cura\CuraEngine`
 ## Updates
 - 0.6.0: $efa multiplier adjusted, --rot-revolve=0 (new default, unlimited revolv), --rot-revolve=1 (single revolv) does performs smart rotate-around to immitate continenous rotation
 - 0.5.2: --rotate, --scale and --translate added for pre-processing model

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ A future version of Slicer4RTN might segment volumes and support multiple conic 
 - Windows (tested on Windows 10)
 
 ## Windows Notes
-* When calling Slic3r, you must give the full path to the slic3r-console.exe file, but you MUST drop the .exe suffix, and write slic3r-console in all lowercase, even if the file is installed as Slic3r-console.exe . For example: `--slicer=c:\instpath\slic3r\slic3r-console`
-* When calling PrusaSlicer, you must give the full path to the prusa-slicer-console.exe file, but you MUST drop the .exe suffix, and write prusa-slicer-console in all lowercase. For example: `--slicer=c:\instpath\PrusaSlicer\prusa-slicer-console`
-* When calling Cura, you must give the full path to the CuraEngine.exe file, but you MUST drop the .exe suffix, and write CuraEngine in the exact form as here (2 capitalized words). For example: `--slicer=c:\instpath\Cura\CuraEngine`
+* When calling Slic3r, you must give the full path to the slic3r-console.exe file.
+* When calling PrusaSlicer, you must give the full path to the prusa-slicer-console.exe file.
+* When calling Cura, you must give the full path to the CuraEngine.exe file.
 ## Updates
 - 0.6.0: $efa multiplier adjusted, --rot-revolve=0 (new default, unlimited revolv), --rot-revolve=1 (single revolv) does performs smart rotate-around to immitate continenous rotation
 - 0.5.2: --rotate, --scale and --translate added for pre-processing model

--- a/slicer4rtn
+++ b/slicer4rtn
@@ -62,11 +62,9 @@ my $slicer;
 $app = basename($0);
 
 if ("$^O" eq "linux") {
-   #($app) = ($0=~/\/([^\/]+)$/);
    @app_path = ("/usr/share/$app","$ENV{HOME}/.config/$app");
    $dest = "/usr/local/bin";
 } elsif ($^O eq "MSWin32") {
-   #($app) = ($0=~/\\([^\\]+)$/);
    @app_path = (catfile($ENV{"PROGRAMDATA"}, $app), catfile($ENV{"APPDATA"}, $app));
 } else {
    print("Unsupported OS $^O");

--- a/slicer4rtn
+++ b/slicer4rtn
@@ -225,6 +225,7 @@ if($conf->{install}) {
    my $dir = catfile(dirname($0), "settings");
    opendir(DIR, $dir);
    my @files = readdir(DIR);
+   closedir(DIR);
    for my $f (@files) {
       next if($f =~ /^[\.]{1,2}$/);
       my $sf = catfile($dir, $f);

--- a/slicer4rtn
+++ b/slicer4rtn
@@ -44,12 +44,26 @@
 use strict;
 use Math::Trig;
 use POSIX;
+use File::Basename;
+use File::Spec::Functions 'catfile';
 #use JSON;
 
 my $APPNAME = 'Slicer4RTN';
 my $VERSION = '0.6.0';
 
-my($app) = ($0=~/\/([^\/]+)$/);
+my $app;
+if ("$^O" eq "linux") {
+   ($app) = ($0=~/\/([^\/]+)$/);
+   @app_path = ("/usr/share/$app","$ENV{HOME}/.config/$app");
+} elsif ($^O eq "MSWin32") {
+   ($app) = ($0=~/\\([^\\]+)$/);
+   @app_path = ("C:\Program Files\$app","C:\Documents and Settings\$username\Application Data\$app");
+} else {
+   $app = "Unknown";
+}
+# $app above sort-of-works but why not use a real portable version?
+$app = basename($0);
+my $username = getlogin || $ENV{LOGNAME} || $ENV{USER} || getpwuid($<);
 
 my $conf = {
    intern_format => 'stl',
@@ -91,8 +105,8 @@ my $confUnset = {
 my %sf2l = ( 'v'=>'verbose', 'k'=>'keep' );
 my(@slicer_args);
 
-foreach my $p ("/usr/share/$app","$ENV{HOME}/.config/$app") {     # -- check system-wide and user settings
-   open(my $fh,"<","$p/$app.ini");
+foreach my $p @app_path {     # -- check system-wide and user settings
+   open(my $fh,"<",catfile($p, "$app.ini");
    while(<$fh>) {
       chop;
       next if(/^\s*#/);
@@ -158,8 +172,8 @@ if($conf->{slicer} =~ /(slic3r|prusa)/) {
    push(@slicer_args,'--start-gcode=;') if(defined $conf->{start_gcode});
    push(@slicer_args,'--end-gcode=;') if(defined $conf->{end_gcode});
    foreach my $s ($conf->{slicer}) {
-      push(@slicer_args,"--load=/usr/share/$app/$s.ini") if(-e "/usr/share/$app/$s.ini");
-      push(@slicer_args,"--load=$ENV{HOME}/.config/$app/$s.ini") if(-e "$ENV{HOME}/.config/$app/$s.ini");
+      push(@slicer_args,"--load=".catfile($app_path[0], "$s.ini")) if(-e catfile($app_path[0], "$s.ini"));
+      push(@slicer_args,"--load=".catfile($app_path[1], "$s.ini")) if(-e catfile($app_path[1], "$s.ini"));
    }
 
 } elsif($conf->{slicer} =~ /mandoline$/) {
@@ -167,8 +181,8 @@ if($conf->{slicer} =~ /(slic3r|prusa)/) {
    push(@slicer_args,'--no-support','--no-raft','-n','-S','bed_center_x=0','-S','bed_center_y=0');
    push(@slicer_args,'--start-gcode=;') if(defined $conf->{start_gcode});
    push(@slicer_args,'--end-gcode=;') if(defined $conf->{end_gcode});
-   foreach my $p ("/usr/share/$app","$ENV{HOME}/.config/$app") {
-      my $c = parseConfig($p."/mandoline.ini");
+   foreach my $p @app_path {
+      my $c = parseConfig(catfile($p, "mandoline.ini"));
       foreach my $k (keys %$c) {
          push(@slicer_args,'-S',"$k=$c->{$k}");
       }
@@ -179,8 +193,8 @@ if($conf->{slicer} =~ /(slic3r|prusa)/) {
    push(@slicer_args,'-s','support_enable=false','-s','skirt_line_count=0','-s','brim_line_count=0','-s','support_brim_line_count=0');
    push(@slicer_args,'-s','machine_start_gcode=;') if(defined $conf->{start_gcode});
    push(@slicer_args,'-s','machine_end_gcode=;') if(defined $conf->{end_gcode});
-   foreach my $p ("/usr/share/$app","$ENV{HOME}/.config/$app") {
-      my $c = parseConfig($p."/CuraEngine.ini");
+   foreach my $p @app_path {
+      my $c = parseConfig(catfile($p, "CuraEngine.ini"));
       foreach my $k (keys %$c) {
          push(@slicer_args,'-s',"$k=$c->{$k}");
       }
@@ -189,8 +203,8 @@ if($conf->{slicer} =~ /(slic3r|prusa)/) {
 } elsif($conf->{slicer} =~ /CuraEngineLegacy$/) {
    push(@slicer_args,'-s','autoCenter=0','-s','objectPosition.X=0','-s','objectPosition.Y=0','-s','layerThickness='.$lhc*1000,
       '-s','skirtLineCount=0','-s','downSkinCount=3','-s','upSkinCount=3','-s','filamentDiameter=1750');
-   foreach my $p ("/usr/share/$app","$ENV{HOME}/.config/$app") {
-      my $c = parseConfig($p."/CuraEngineLegacy.ini");
+   foreach my $p @app_path {
+      my $c = parseConfig(catfile($p, "CuraEngineLegacy.ini"));
       foreach my $k (keys %$c) {
          push(@slicer_args,'-s',"$k=$c->{$k}");
       }
@@ -200,8 +214,8 @@ if($conf->{slicer} =~ /(slic3r|prusa)/) {
    push(@slicer_args,'--layer_height='.$lhc);
    push(@slicer_args,'--machine_start_gcode=;') if(defined $conf->{start_gcode});
    push(@slicer_args,'--machine_end_gcode=;') if(defined $conf->{end_gcode});
-   foreach my $p ("/usr/share/$app","$ENV{HOME}/.config/$app") {
-      my $c = parseConfig($p."/cura-slicer.ini");
+   foreach my $p @app_path {
+      my $c = parseConfig(catfile($p, "cura-slicer.ini"));
       foreach my $k (keys %$c) {
          push(@slicer_args,"--$k=$c->{$k}");
       }
@@ -306,7 +320,7 @@ foreach my $fn (@fs) {
    
    measureModel($m), levelModel($m); # if($conf->{slicer}=~/Cura/);
    
-   my($tmp_gcode,$tmp_model) = ("./tmp-$$.gcode","./tmp-$$.$conf->{intern_format}");
+   my($tmp_gcode,$tmp_model) = (catfile(".", "tmp-$$.gcode"),catfile(".", "tmp-$$.$conf->{intern_format}"));
    print "   3/5 write temporary model\n";
 
    $tmp_model =~ s/\.\w+$/.stl/ if($conf->{slicer} =~ /(cura|mandoline)/i);      # -- cura & mandoline only manage STL
@@ -318,7 +332,7 @@ foreach my $fn (@fs) {
    if(fork()==0) {
       my(@a) = ($conf->{slicer});
       push(@a,$conf->{slicer} =~ /CuraEngine$/ ? 
-         ("slice","-j","/usr/share/$app/fdmprinter.def.json","-s","machine_center_is_zero=true","-s","extruder_nr=0",@slicer_args,"-o",$tmp_gcode,"-l",$tmp_model) :
+         ("slice","-j",catfile($app_path[0], "fdmprinter.def.json"),"-s","machine_center_is_zero=true","-s","extruder_nr=0",@slicer_args,"-o",$tmp_gcode,"-l",$tmp_model) :
          (@slicer_args,"-o",$tmp_gcode,$tmp_model) );
       print "$app INF: @a\n" if($conf->{verbose});
       # -- is important, as CuraEngine is chatty and closing only STDERR will pollute the resulting G-code with error messages(!!)

--- a/slicer4rtn
+++ b/slicer4rtn
@@ -47,6 +47,7 @@ use POSIX;
 use File::Basename;
 use File::Spec::Functions 'catfile';
 use File::Copy;
+use File::Compare;
 #use JSON;
 
 my $APPNAME = 'Slicer4RTN';
@@ -188,8 +189,9 @@ if($conf->{version}) {
 # Install script...
 #
 if($conf->{install}) {
-   $dest = catfile($conf->{user} ? $home : $ENV{"PROGRAMDATA"}, "bin");
-   for my $d ($dest, $app_path[1]) {
+   $dest = catfile(catfile(($conf->{user} ? $home : $ENV{"PROGRAMDATA"}), $app), "bin");
+   # create user and glogal setting dirs
+   for my $d (@app_path, $dest) {
       if (! -d $d) {
          print ($d , " doesnt exist! Creating it...\n");
          mkdir ($d);
@@ -199,15 +201,18 @@ if($conf->{install}) {
          }
       }
    }
+   # copy app to bin dir
    $fullapp =  catfile($dest, $app);
+   copy ($0, $fullapp);
    if (! -e $fullapp) {
-      print("$fullapp doesn't exist! copying it from $0...\n");
-      copy ($0, $fullapp);
-      if (! -e $fullapp) {
-         print("$fullapp creation failed, exiting :-(\n");
-         exit;
-      }
+      print("$fullapp creation failed, exiting :-(\n");
+      exit;
    }
+   if (compare($0, $fullapp)) {
+      printf ("File not copied correctly. Perhaps you have a permission problem writing to $fullapp ?\n");
+      exit;
+   }
+   # create empty user setting files
    for my $ini_file ("slicer4rtn.ini", "slic3r.ini") {
       my $ini = catfile($app_path[1], $ini_file);
       if (! -e $ini) {
@@ -218,6 +223,24 @@ if($conf->{install}) {
             print("$ini creation failed, exiting :-(\n");
             exit;
          }
+      }
+   }
+   # copy global setting files
+   my $dir = catfile(dirname($0), "settings");
+   opendir(DIR, $dir);
+   my @files = readdir(DIR);
+   for my $f (@files) {
+      next if($f =~ /^[\.]{1,2}$/);
+      my $sf = catfile($dir, $f);
+      copy($sf, $app_path[0]);
+      my $df = catfile($app_path[0], $f);
+      if (! -e $df) {
+         print("$df creation failed, exiting :-(\n");
+         exit;
+      }
+      if (compare($sf, $df)) {
+         printf ("File not copied correctly. Perhaps you have a permission problem writing to $df ?\n");
+         exit;
       }
    }
    exit;

--- a/slicer4rtn
+++ b/slicer4rtn
@@ -964,7 +964,7 @@ sub writeSTLB {
    # REAL32[3]  Vertex 3
    # UINT16  Attribute byte count
    # end
-   open(my $fh,">",$fn);
+   open(my $fh,">:raw",$fn);
    print $fh " "x80;
    my $ft = 0;
    foreach my $v (@{$m->{volumes}}) {
@@ -1029,6 +1029,7 @@ sub readSTL {
       # UINT16  Attribute byte count
       # end
       my $buff;
+      binmode ($fh);
 
       read($fh,$buff,80);
       read($fh,$buff,4);

--- a/slicer4rtn
+++ b/slicer4rtn
@@ -52,6 +52,8 @@ my $APPNAME = 'Slicer4RTN';
 my $VERSION = '0.6.0';
 
 my $app;
+my @app_path;
+
 if ("$^O" eq "linux") {
    ($app) = ($0=~/\/([^\/]+)$/);
    @app_path = ("/usr/share/$app","$ENV{HOME}/.config/$app");
@@ -105,8 +107,8 @@ my $confUnset = {
 my %sf2l = ( 'v'=>'verbose', 'k'=>'keep' );
 my(@slicer_args);
 
-foreach my $p @app_path {     # -- check system-wide and user settings
-   open(my $fh,"<",catfile($p, "$app.ini");
+foreach my $p (@app_path) {     # -- check system-wide and user settings
+   open(my $fh,"<",catfile($p, "$app.ini"));
    while(<$fh>) {
       chop;
       next if(/^\s*#/);
@@ -181,7 +183,7 @@ if($conf->{slicer} =~ /(slic3r|prusa)/) {
    push(@slicer_args,'--no-support','--no-raft','-n','-S','bed_center_x=0','-S','bed_center_y=0');
    push(@slicer_args,'--start-gcode=;') if(defined $conf->{start_gcode});
    push(@slicer_args,'--end-gcode=;') if(defined $conf->{end_gcode});
-   foreach my $p @app_path {
+   foreach my $p (@app_path) {
       my $c = parseConfig(catfile($p, "mandoline.ini"));
       foreach my $k (keys %$c) {
          push(@slicer_args,'-S',"$k=$c->{$k}");
@@ -193,7 +195,7 @@ if($conf->{slicer} =~ /(slic3r|prusa)/) {
    push(@slicer_args,'-s','support_enable=false','-s','skirt_line_count=0','-s','brim_line_count=0','-s','support_brim_line_count=0');
    push(@slicer_args,'-s','machine_start_gcode=;') if(defined $conf->{start_gcode});
    push(@slicer_args,'-s','machine_end_gcode=;') if(defined $conf->{end_gcode});
-   foreach my $p @app_path {
+   foreach my $p (@app_path) {
       my $c = parseConfig(catfile($p, "CuraEngine.ini"));
       foreach my $k (keys %$c) {
          push(@slicer_args,'-s',"$k=$c->{$k}");
@@ -203,7 +205,7 @@ if($conf->{slicer} =~ /(slic3r|prusa)/) {
 } elsif($conf->{slicer} =~ /CuraEngineLegacy$/) {
    push(@slicer_args,'-s','autoCenter=0','-s','objectPosition.X=0','-s','objectPosition.Y=0','-s','layerThickness='.$lhc*1000,
       '-s','skirtLineCount=0','-s','downSkinCount=3','-s','upSkinCount=3','-s','filamentDiameter=1750');
-   foreach my $p @app_path {
+   foreach my $p (@app_path) {
       my $c = parseConfig(catfile($p, "CuraEngineLegacy.ini"));
       foreach my $k (keys %$c) {
          push(@slicer_args,'-s',"$k=$c->{$k}");
@@ -214,7 +216,7 @@ if($conf->{slicer} =~ /(slic3r|prusa)/) {
    push(@slicer_args,'--layer_height='.$lhc);
    push(@slicer_args,'--machine_start_gcode=;') if(defined $conf->{start_gcode});
    push(@slicer_args,'--machine_end_gcode=;') if(defined $conf->{end_gcode});
-   foreach my $p @app_path {
+   foreach my $p (@app_path) {
       my $c = parseConfig(catfile($p, "cura-slicer.ini"));
       foreach my $k (keys %$c) {
          push(@slicer_args,"--$k=$c->{$k}");

--- a/slicer4rtn
+++ b/slicer4rtn
@@ -55,23 +55,19 @@ my $VERSION = '0.6.0';
 
 my $app;
 my $fullapp;
-my $home;
 my $dest;
 my @app_path;
 my $slicer;
 
 $app = basename($0);
-my $username = getlogin || $ENV{LOGNAME} || $ENV{USER} || getpwuid($<);
 
 if ("$^O" eq "linux") {
    #($app) = ($0=~/\/([^\/]+)$/);
    @app_path = ("/usr/share/$app","$ENV{HOME}/.config/$app");
-   $home = $ENV{"HOME"};
    $dest = "/usr/local/bin";
 } elsif ($^O eq "MSWin32") {
    #($app) = ($0=~/\\([^\\]+)$/);
    @app_path = (catfile($ENV{"PROGRAMDATA"}, $app), catfile($ENV{"APPDATA"}, $app));
-   $home = $ENV{"USERPROFILE"};
 } else {
    print("Unsupported OS $^O");
    exit;
@@ -189,7 +185,7 @@ if($conf->{version}) {
 # Install script...
 #
 if($conf->{install}) {
-   $dest = catfile(catfile(($conf->{user} ? $home : $ENV{"PROGRAMDATA"}), $app), "bin");
+   $dest = catfile(catfile($ENV{"PROGRAMDATA"}, $app), "bin");
    # create user and glogal setting dirs
    for my $d (@app_path, $dest) {
       if (! -d $d) {
@@ -316,7 +312,6 @@ if($conf->{help} || @fs <= 0) {
       -v or --verbose      increase verbosity
       --version            display version and exit
       --install            perform initial install
-      --user               only relevant when used with --install on a Windows machine - install for current user or all system users
       -k or --keep         keep all temporary files (temp.stl, temp.gcode)
       --rotate=<x,y,z>     rotate model
       --translate=<x,y,z>  translate model

--- a/slicer4rtn
+++ b/slicer4rtn
@@ -46,26 +46,35 @@ use Math::Trig;
 use POSIX;
 use File::Basename;
 use File::Spec::Functions 'catfile';
+use File::Copy;
 #use JSON;
 
 my $APPNAME = 'Slicer4RTN';
 my $VERSION = '0.6.0';
 
 my $app;
+my $fullapp;
+my $home;
+my $dest;
 my @app_path;
 
-if ("$^O" eq "linux") {
-   ($app) = ($0=~/\/([^\/]+)$/);
-   @app_path = ("/usr/share/$app","$ENV{HOME}/.config/$app");
-} elsif ($^O eq "MSWin32") {
-   ($app) = ($0=~/\\([^\\]+)$/);
-   @app_path = ("C:\Program Files\$app","C:\Documents and Settings\$username\Application Data\$app");
-} else {
-   $app = "Unknown";
-}
-# $app above sort-of-works but why not use a real portable version?
 $app = basename($0);
 my $username = getlogin || $ENV{LOGNAME} || $ENV{USER} || getpwuid($<);
+
+if ("$^O" eq "linux") {
+   #($app) = ($0=~/\/([^\/]+)$/);
+   @app_path = ("/usr/share/$app","$ENV{HOME}/.config/$app");
+   $home = $ENV{"HOME"};
+   $dest = "/usr/local/bin";
+} elsif ($^O eq "MSWin32") {
+   #($app) = ($0=~/\\([^\\]+)$/);
+   @app_path = ("C:\\Program Files\\$app","C:\\Documents and Settings\\$username\\Application Data\\$app");
+   $home = $ENV{"USERPROFILE"};
+   $dest = catfile($home, "bin");
+} else {
+   print("Unsupported OS $^O");
+   exit;
+}
 
 my $conf = {
    intern_format => 'stl',
@@ -163,6 +172,44 @@ if($conf->{version}) {
    exit 0;
 }
 
+#
+# Install script...
+#
+if($conf->{install}) {
+   for my $d ($dest, $app_path[1]) {
+      if (! -d $d) {
+         print ($d , " doesnt exist! Creating it...\n");
+         mkdir ($d);
+         if (! -d $d) {
+            print("Directory creation failed, exiting :-(\n");
+            exit;
+         }
+      }
+   }
+   $fullapp =  catfile($dest, $app);
+   if (! -e $fullapp) {
+      print("$fullapp doesn't exist! copying it from $0...\n");
+      copy ($0, $fullapp);
+      if (! -e $fullapp) {
+         print("$fullapp creation failed, exiting :-(\n");
+         exit;
+      }
+   }
+   for my $ini_file ("slicer4rtn.ini", "slic3r.ini") {
+      my $ini = catfile($app_path[1], $ini_file);
+      if (! -e $ini) {
+         print("$ini doesn't exist! Creating it ...\n");
+         open(my $fho,">",$ini) || die "$app: ERROR: cannot write '$ini'\n";
+         close($fho);
+         if (! -e $ini) {
+            print("$ini creation failed, exiting :-(\n");
+            exit;
+         }
+      }
+   }
+   exit;
+}
+
 my $lhc = $conf->{layer_height}/cos($conf->{angle}/180*pi());
 
 # -- now we know slicer, add sane & important settings, and convert CLI opts into slicer args
@@ -232,6 +279,7 @@ if($conf->{help} || @fs <= 0) {
    options:
       -v or --verbose      increase verbosity
       --version            display version and exit
+      --install            perform initial install
       -k or --keep         keep all temporary files (temp.stl, temp.gcode)
       --rotate=<x,y,z>     rotate model
       --translate=<x,y,z>  translate model

--- a/slicer4rtn
+++ b/slicer4rtn
@@ -57,6 +57,7 @@ my $fullapp;
 my $home;
 my $dest;
 my @app_path;
+my $slicer;
 
 $app = basename($0);
 my $username = getlogin || $ENV{LOGNAME} || $ENV{USER} || getpwuid($<);
@@ -68,9 +69,8 @@ if ("$^O" eq "linux") {
    $dest = "/usr/local/bin";
 } elsif ($^O eq "MSWin32") {
    #($app) = ($0=~/\\([^\\]+)$/);
-   @app_path = ("C:\\Program Files\\$app","C:\\Documents and Settings\\$username\\Application Data\\$app");
+   @app_path = (catfile($ENV{"PROGRAMDATA"}, $app), catfile($ENV{"APPDATA"}, $app));
    $home = $ENV{"USERPROFILE"};
-   $dest = catfile($home, "bin");
 } else {
    print("Unsupported OS $^O");
    exit;
@@ -132,14 +132,21 @@ my @fs;
 my @slicer_args_cli;
 my @transform;
 
+if (defined  $conf->{slicer}) {
+      $slicer = basename($conf->{slicer});
+      $slicer =~ s/\.[\w\d]+$//;
+      if ($conf->{slicer} ne $slicer) {
+         print("Slicer is $slicer\n") if($conf->{verbose});
+      }
+}
+
 foreach(@ARGV) {                            # -- preprocess all command-line arguments
    my($s,$k,$v);
 
    if(/^--(slicer)\.([\w\-]+)=(.*)/) {      # -- slicer specific declared
-      $s = $1, $k = $2, $v = $3;
       push(@slicer_args_cli,
-         $conf->{slicer} eq 'mandoline' ? ("-S","$k=$v") : 
-         $conf->{slicer} =~ /Cura/ ? ("-s","$k=$v") : "--$k=$v"
+         $slicer eq 'mandoline' ? ("-S","$k=$v") : 
+         $slicer =~ /Cura/ ? ("-s","$k=$v") : "--$k=$v"
       );
       next;
    }
@@ -148,11 +155,16 @@ foreach(@ARGV) {                            # -- preprocess all command-line arg
       my $k_ = $k; $k_ =~ s/\-/_/g;
       if(!defined $conf->{$k_} && !defined $confUnset->{$k_}) {               # -- slicer args
          push(@slicer_args_cli,
-            $conf->{slicer} eq 'mandoline' ? ("-S","$k=$v") : 
-            $conf->{slicer} =~ /Cura/ ? ("-s","$k=$v") : "--$k=$v");
+            $slicer eq 'mandoline' ? ("-S","$k=$v") : 
+            $slicer =~ /Cura/ ? ("-s","$k=$v") : "--$k=$v");
       } elsif($k_ =~ /^(rotate|translate|scale)$/) {
          push(@transform,"$k_=$v");
       } else {
+         if ($k_ eq "slicer") {
+            $slicer = basename($v);
+            $slicer =~ s/\.[\w\d]+$//;
+            print("Slicer is $slicer\n") if($conf->{verbose});
+         }
          $conf->{$k_} = $v;                                                   # -- general settings
       }
       next;
@@ -176,6 +188,7 @@ if($conf->{version}) {
 # Install script...
 #
 if($conf->{install}) {
+   $dest = catfile($conf->{user} ? $home : $ENV{"PROGRAMDATA"}, "bin");
    for my $d ($dest, $app_path[1]) {
       if (! -d $d) {
          print ($d , " doesnt exist! Creating it...\n");
@@ -213,19 +226,19 @@ if($conf->{install}) {
 my $lhc = $conf->{layer_height}/cos($conf->{angle}/180*pi());
 
 # -- now we know slicer, add sane & important settings, and convert CLI opts into slicer args
-if($conf->{slicer} =~ /(slic3r|prusa)/) {
-   push(@slicer_args,'--gcode-comments','--skirts=0', ($conf->{slicer}=~/prusa/?'--center=':'--print-center=').("0,0"||$conf->{center}));
+if($slicer =~ /(slic3r|prusa)/) {
+   push(@slicer_args,'--gcode-comments','--skirts=0', ($slicer=~/prusa/?'--center=':'--print-center=').("0,0"||$conf->{center}));
       #'--before-layer-gcode=;LAYER:[layer_num]');  # -- make it Cura compatible to catch layer change
-   push(@slicer_args,'-s') if($conf->{slicer}=~/prusa/);    # -- slice G-code
+   push(@slicer_args,'-s') if($slicer=~/prusa/);    # -- slice G-code
    push(@slicer_args,'--layer-height='.$lhc);
    push(@slicer_args,'--start-gcode=;') if(defined $conf->{start_gcode});
    push(@slicer_args,'--end-gcode=;') if(defined $conf->{end_gcode});
-   foreach my $s ($conf->{slicer}) {
+   foreach my $s ($slicer) {
       push(@slicer_args,"--load=".catfile($app_path[0], "$s.ini")) if(-e catfile($app_path[0], "$s.ini"));
       push(@slicer_args,"--load=".catfile($app_path[1], "$s.ini")) if(-e catfile($app_path[1], "$s.ini"));
    }
 
-} elsif($conf->{slicer} =~ /mandoline$/) {
+} elsif($slicer =~ /mandoline$/) {
    push(@slicer_args,'-S','layer_height='.$lhc);
    push(@slicer_args,'--no-support','--no-raft','-n','-S','bed_center_x=0','-S','bed_center_y=0');
    push(@slicer_args,'--start-gcode=;') if(defined $conf->{start_gcode});
@@ -237,7 +250,7 @@ if($conf->{slicer} =~ /(slic3r|prusa)/) {
       }
    }
    
-} elsif($conf->{slicer} =~ /CuraEngine$/) {
+} elsif($slicer =~ /CuraEngine$/) {
    push(@slicer_args,'-s','layer_height='.$lhc);
    push(@slicer_args,'-s','support_enable=false','-s','skirt_line_count=0','-s','brim_line_count=0','-s','support_brim_line_count=0');
    push(@slicer_args,'-s','machine_start_gcode=;') if(defined $conf->{start_gcode});
@@ -249,7 +262,7 @@ if($conf->{slicer} =~ /(slic3r|prusa)/) {
       }
    }
 
-} elsif($conf->{slicer} =~ /CuraEngineLegacy$/) {
+} elsif($slicer =~ /CuraEngineLegacy$/) {
    push(@slicer_args,'-s','autoCenter=0','-s','objectPosition.X=0','-s','objectPosition.Y=0','-s','layerThickness='.$lhc*1000,
       '-s','skirtLineCount=0','-s','downSkinCount=3','-s','upSkinCount=3','-s','filamentDiameter=1750');
    foreach my $p (@app_path) {
@@ -258,7 +271,7 @@ if($conf->{slicer} =~ /(slic3r|prusa)/) {
          push(@slicer_args,'-s',"$k=$c->{$k}");
       }
    }
-} elsif($conf->{slicer} =~ /cura-slicer$/) {
+} elsif($slicer =~ /cura-slicer$/) {
    push(@slicer_args,"-vv") if($conf->{verbose});
    push(@slicer_args,'--layer_height='.$lhc);
    push(@slicer_args,'--machine_start_gcode=;') if(defined $conf->{start_gcode});
@@ -280,6 +293,7 @@ if($conf->{help} || @fs <= 0) {
       -v or --verbose      increase verbosity
       --version            display version and exit
       --install            perform initial install
+      --user               only relevant when used with --install on a Windows machine - install for current user or all system users
       -k or --keep         keep all temporary files (temp.stl, temp.gcode)
       --rotate=<x,y,z>     rotate model
       --translate=<x,y,z>  translate model
@@ -373,7 +387,7 @@ foreach my $fn (@fs) {
    my($tmp_gcode,$tmp_model) = (catfile(".", "tmp-$$.gcode"),catfile(".", "tmp-$$.$conf->{intern_format}"));
    print "   3/5 write temporary model\n";
 
-   $tmp_model =~ s/\.\w+$/.stl/ if($conf->{slicer} =~ /(cura|mandoline)/i);      # -- cura & mandoline only manage STL
+   $tmp_model =~ s/\.\w+$/.stl/ if($slicer =~ /(cura|mandoline)/i);      # -- cura & mandoline only manage STL
 
    writeModel($tmp_model,$m);
    push(@rm,$tmp_model);
@@ -381,12 +395,12 @@ foreach my $fn (@fs) {
    print "   4/5 slice ($conf->{slicer}) model\n";
    if(fork()==0) {
       my(@a) = ($conf->{slicer});
-      push(@a,$conf->{slicer} =~ /CuraEngine$/ ? 
+      push(@a,$slicer =~ /CuraEngine$/ ? 
          ("slice","-j",catfile($app_path[0], "fdmprinter.def.json"),"-s","machine_center_is_zero=true","-s","extruder_nr=0",@slicer_args,"-o",$tmp_gcode,"-l",$tmp_model) :
          (@slicer_args,"-o",$tmp_gcode,$tmp_model) );
       print "$app INF: @a\n" if($conf->{verbose});
       # -- is important, as CuraEngine is chatty and closing only STDERR will pollute the resulting G-code with error messages(!!)
-      close STDERR, close STDOUT if($conf->{slicer} =~ /CuraEngine$/ && $conf->{verbose}==0);      
+      close STDERR, close STDOUT if($slicer =~ /CuraEngine$/ && $conf->{verbose}==0);      
       exec(@a);
       exit 0;
    }
@@ -394,7 +408,7 @@ foreach my $fn (@fs) {
    if(!-e "$tmp_gcode") {
       print "$app ERROR: slicer did not generate any gcode, abort.\n";
       print "$app HINT: execute with -v to see the actual problem\n" unless($conf->{verbose});
-      print "$app HINT: increase --subdivide=.. more and try again, or use --slicer=slic3r instead\n" if($conf->{slicer}=~/prusa/);
+      print "$app HINT: increase --subdivide=.. more and try again, or use --slicer=slic3r instead\n" if($slicer=~/prusa/);
       unlink @rm unless($conf->{keep});
       exit -1;
    }
@@ -523,7 +537,7 @@ sub mapGcode {
    #                   off = tot - min - tot/2
    
    my($ixoff,$iyoff) = (0,0);
-   if($conf->{slicer}=~/(slic3r|prusa)/) {
+   if($slicer=~/(slic3r|prusa)/) {
       $ixoff = $m->{size}[0] - abs($m->{min}[0]) - $m->{size}[0] / 2;
       $iyoff = $m->{size}[1] - abs($m->{min}[1]) - $m->{size}[1] / 2;
    }


### PR DESCRIPTION
Here is a Windows port of the script. The original version had a few issues:
* STL binary files were not opened in raw mode, breaking them due CR/LF issues.
* slicer type checks took into account filename extension (.exe) so I relaxed that.
* I chose a sane location for all the user and global dirs/files on a Windows platform.
* Fixed forward/backward slash directory compatibility by using `basename()` and `catfile()`.
* Updated `README.md` with a Windows section, including the specific filenames to be used for the various slicer options.

I was careful, and I hope I didn't break the Linux version, but I haven't ran all checks on the Linux side because I don't have all the slicers installed on my machine.

I also added an `--install` flag which helps Windows users by not needing to install `make` just for installation. It should also work on Linux using the existing paths (`~/.config` and `/usr/share`).

